### PR TITLE
Favourite Cleaner Feature Implementation

### DIFF
--- a/src/main/java/com/cleanme/controller/FavouriteController.java
+++ b/src/main/java/com/cleanme/controller/FavouriteController.java
@@ -1,0 +1,37 @@
+package com.cleanme.controller;
+
+import com.cleanme.dto.AddFavouriteRequest;
+import com.cleanme.dto.FavouriteDto;
+import com.cleanme.service.FavouriteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/favourites")
+@RequiredArgsConstructor
+public class FavouriteController {
+
+    private final FavouriteService favouriteService;
+
+    @PostMapping
+    public ResponseEntity<Void> addFavourite(@RequestBody @Valid AddFavouriteRequest request) {
+        favouriteService.addFavourite(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{clientId}")
+    public ResponseEntity<List<FavouriteDto>> getFavourites(@PathVariable UUID clientId) {
+        return ResponseEntity.ok(favouriteService.getFavourites(clientId));
+    }
+
+    @DeleteMapping("/{clientId}/{cleanerId}")
+    public ResponseEntity<Void> removeFavourite(@PathVariable UUID clientId, @PathVariable UUID cleanerId) {
+        favouriteService.removeFavourite(clientId, cleanerId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/cleanme/dto/AddFavouriteRequest.java
+++ b/src/main/java/com/cleanme/dto/AddFavouriteRequest.java
@@ -1,0 +1,11 @@
+package com.cleanme.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class AddFavouriteRequest {
+    private UUID clientId;
+    private UUID cleanerId;
+}

--- a/src/main/java/com/cleanme/dto/FavouriteDto.java
+++ b/src/main/java/com/cleanme/dto/FavouriteDto.java
@@ -1,0 +1,15 @@
+package com.cleanme.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class FavouriteDto {
+    private UUID cleanerId;
+    private String cleanerName;
+}
+
+// Ako bude potrebe za vise informacija o cleaneru dodaj

--- a/src/main/java/com/cleanme/entity/FavouriteEntity.java
+++ b/src/main/java/com/cleanme/entity/FavouriteEntity.java
@@ -1,0 +1,28 @@
+package com.cleanme.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "favourites",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"client_id", "cleaner_id"})
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavouriteEntity {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    @ManyToOne
+    @JoinColumn(name = "client_id", nullable = false)
+    private UsersEntity client;
+
+    @ManyToOne
+    @JoinColumn(name = "cleaner_id", nullable = false)
+    private UsersEntity cleaner;
+}

--- a/src/main/java/com/cleanme/repository/FavouriteRepository.java
+++ b/src/main/java/com/cleanme/repository/FavouriteRepository.java
@@ -1,0 +1,15 @@
+package com.cleanme.repository;
+
+import com.cleanme.entity.FavouriteEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface FavouriteRepository extends JpaRepository<FavouriteEntity, UUID> {
+    List<FavouriteEntity> findByClient_Uid(UUID clientId);
+
+    boolean existsByClient_UidAndCleaner_Uid(UUID clientId, UUID cleanerId);
+
+    void deleteByClient_UidAndCleaner_Uid(UUID clientId, UUID cleanerId);
+}

--- a/src/main/java/com/cleanme/service/FavouriteService.java
+++ b/src/main/java/com/cleanme/service/FavouriteService.java
@@ -1,0 +1,62 @@
+package com.cleanme.service;
+
+import com.cleanme.dto.AddFavouriteRequest;
+import com.cleanme.dto.FavouriteDto;
+import com.cleanme.entity.FavouriteEntity;
+import com.cleanme.entity.UsersEntity;
+import com.cleanme.enums.UserType;
+import com.cleanme.repository.FavouriteRepository;
+import com.cleanme.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FavouriteService {
+
+    private final FavouriteRepository favouriteRepository;
+    private final UsersRepository usersRepository;
+
+    public void addFavourite(AddFavouriteRequest request) {
+        UUID clientId = request.getClientId();
+        UUID cleanerId = request.getCleanerId();
+
+        if (favouriteRepository.existsByClient_UidAndCleaner_Uid(clientId, cleanerId)) {
+            throw new RuntimeException("Already in favourites.");
+        }
+
+        UsersEntity client = usersRepository.findById(clientId)
+                .orElseThrow(() -> new RuntimeException("Client not found."));
+
+        UsersEntity cleaner = usersRepository.findById(cleanerId)
+                .orElseThrow(() -> new RuntimeException("Cleaner not found."));
+
+        if (cleaner.getUserType() != UserType.CLEANER) {
+            throw new RuntimeException("Selected user is not a cleaner.");
+        }
+
+        FavouriteEntity favourite = new FavouriteEntity();
+        favourite.setClient(client);
+        favourite.setCleaner(cleaner);
+
+        favouriteRepository.save(favourite);
+    }
+
+    public List<FavouriteDto> getFavourites(UUID clientId) {
+        return favouriteRepository.findByClient_Uid(clientId)
+                .stream()
+                .map(fav -> new FavouriteDto(
+                        fav.getCleaner().getUid(),
+                        fav.getCleaner().getFirstName() + " " + fav.getCleaner().getLastName()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public void removeFavourite(UUID clientId, UUID cleanerId) {
+        favouriteRepository.deleteByClient_UidAndCleaner_Uid(clientId, cleanerId);
+    }
+}


### PR DESCRIPTION
# ⭐ Favourites Feature Implementation

## ✅ Overview

This PR introduces a complete `favourites` module which allows CLIENT users to manage their favourite CLEANER users. Functionality includes adding, listing, and removing favourites.

---

## 🧩 Features

### POST `/favourites`
- Adds a cleaner to the client’s favourites
- Prevents duplicate entries per client-cleaner pair
- Validates that target user is of type `CLEANER`

### GET `/favourites/{clientId}`
- Returns a list of cleaner DTOs that the client has marked as favourite
- Each cleaner includes `uid` and full name

### DELETE `/favourites/{clientId}/{cleanerId}`
- Removes the specified cleaner from the client’s favourites

---

## 🛠️ Backend Components

- `FavouriteEntity` – maps favourite relationship between client and cleaner
- `AddFavouriteRequest` DTO – input model for adding favourites
- `FavouriteDto` DTO – output model containing cleaner ID and name
- `FavouriteRepository` – JPA interface for accessing favourites
- `FavouriteService` – handles all business logic
- `FavouriteController` – exposes REST API endpoints

---

## 🔐 Security

- All `/favourites/**` endpoints are JWT-protected
- Frontend must send valid `Authorization: Bearer <token>` in headers
- Service ensures only `CLEANER` users can be added as favourites

---

## 🧪 Tested Scenarios

- ✅ Add cleaner to favourites (if not already added)
- ✅ Fetch favourites for a client
- ✅ Remove a cleaner from favourites
- ✅ Reject adding the same cleaner twice
- ✅ Reject adding a user who is not of type CLEANER




